### PR TITLE
Version 0.1.0.beta3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Alexey 
+Copyright (c) 2024 Croco Factory
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -25,19 +25,22 @@ Here is example of OOP style.
 ```python
 from typing import Annotated, Any
 from httpx import Response
-from sensei import Router, Query, Path, APIModel, Header, Args
-from sensei.cases import pascal_case
+from sensei import Router, Query, Path, APIModel, Header, Args, pascal_case
 
-router = Router(
-    'https://reqres.in/api',
-    header_case=pascal_case
-)
+router = Router('https://reqres.in/api')
 
 
 @router.model()
 class BaseModel(APIModel):
     def __finalize_json__(self, json: dict[str, Any]) -> dict[str, Any]:
         return json['data']
+
+    def __prepare_args__(self, args: Args) -> Args:
+        args.headers['X-Token'] = 'Hello token!'
+        return args
+
+    def __header_case__(self, s: str) -> str:
+        return pascal_case(s)
 
 
 class User(BaseModel):
@@ -87,7 +90,6 @@ users = User.query(per_page=7)
 user_id = users[0].id
 user = User.get(user_id)
 print(user == users[0])
-
 ```
 
 Example of functional style.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ router = Router(
 
 @router.model()
 class BaseModel(APIModel):
-    @staticmethod
-    def __process_json__(json: dict[str, Any]) -> dict[str, Any]:
+    def __finalize_json__(self, json: dict[str, Any]) -> dict[str, Any]:
         return json['data']
 
 
@@ -59,13 +58,13 @@ class User(BaseModel):
         ...
 
     @staticmethod
-    @query.initializer
+    @query.prepare
     def _query_in(args: Args) -> Args:
         args.headers['Hello-World'] = 'hello world'
         return args
 
     @staticmethod
-    @query.finalizer
+    @query.finalize
     def _query_out(
             response: Response,
     ) -> list["User"]:
@@ -79,16 +78,16 @@ class User(BaseModel):
         ...
 
     @staticmethod
-    @get.finalizer
+    @get.finalize
     def _get_out(response: Response) -> "User":
         json = response.json()
         return User(**json)
-
 
 users = User.query(per_page=7)
 user_id = users[0].id
 user = User.get(user_id)
 print(user == users[0])
+
 ```
 
 Example of functional style.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # sensei
+<a href="https://pypi.org/project/sensei/">
 <h1 align="center">
-<img src="https://raw.githubusercontent.com/CrocoFactory/sensei/main/branding/logo/transparent_red.png" width="300">
+<img alt="Logo Banner" src="https://raw.githubusercontent.com/CrocoFactory/sensei/main/branding/logo/transparent_red.png" width="300">
 </h1><br>
+</a>
 
 [![PyPi Version](https://img.shields.io/pypi/v/sensei)](https://pypi.org/project/sensei/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/sensei?label=downloads)](https://pypi.org/project/sensei/)
@@ -10,7 +12,8 @@
 [![Development Status](https://img.shields.io/pypi/status/sensei)](https://pypi.org/project/sensei/)
 
 The python framework, providing fast and robust way to build client-side API wrappers.
-                       
+                           
+- **[Maintain](https://www.patreon.com/user/membership?u=142083211)**
 - **[Bug reports](https://github.com/CrocoFactory/sensei/issues)**
 
 Source code is made available under the [MIT License](LICENSE).  
@@ -22,9 +25,10 @@ Here is example of OOP style.
 ```python
 from typing import Annotated
 from httpx import Response
-from sensei import Router, Query, Path, APIModel
+from sensei import Router, Query, Path, APIModel, Header, Args
+from sensei.cases import pascal_case
 
-router = Router('https://reqres.in/api')
+router = Router('https://reqres.in/api', header_case=pascal_case)
 
 
 class User(APIModel):
@@ -40,8 +44,15 @@ class User(APIModel):
             cls,
             page: Annotated[int, Query(1)],
             per_page: Annotated[int, Query(3, le=7)],
+            bearer_token: Annotated[str, Header('secret', le=10)],
     ) -> list["User"]:
         ...
+
+    @staticmethod
+    @query.initializer()
+    def _query_in(args: Args) -> Args:
+        args.headers['Hello-World'] = 'hello world'
+        return args
 
     @staticmethod
     @query.finalizer()
@@ -68,7 +79,6 @@ users = User.query(per_page=7)
 user_id = users[0].id
 user = User.get(user_id)
 print(user == users[0])
-
 ```
 
 Example of functional style.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'sensei'
-version = '0.1.0.beta2'
+version = '0.1.0.beta3'
 description = 'The python framework, providing fast and robust way to build client-side API wrappers.'
 authors = ['Alexey  <axbelenkov@gmail.com>']
 license = 'MIT'

--- a/sensei/__init__.py
+++ b/sensei/__init__.py
@@ -1,4 +1,4 @@
-from ._internal import Router
+from ._internal import Router, Args
 from .params import Path, Query, Cookie, Header, Body
 from .client import RateLimit, Manager, Client, AsyncClient
 from .api_model import APIModel

--- a/sensei/__init__.py
+++ b/sensei/__init__.py
@@ -3,3 +3,4 @@ from .params import Path, Query, Cookie, Header, Body
 from .client import RateLimit, Manager, Client, AsyncClient
 from .api_model import APIModel
 from .cases import *
+from ._utils import fill_path_params

--- a/sensei/_base_client.py
+++ b/sensei/_base_client.py
@@ -1,105 +1,39 @@
-from abc import abstractmethod, ABCMeta, ABC
-from typing import Mapping, Any
+from abc import abstractmethod, ABC
+from ._utils import get_path_params, fill_path_params
 from .types import IRateLimit, IResponse
+from sensei._descriptors import RateLimitAttr, PortAttr
 
 
-class _ClientPropsMeta(ABCMeta):
-    def __new__(
-            cls,
-            cls_name: str,
-            bases: tuple[type[Any], ...],
-            namespace: dict[str, Any],
-    ):
-        namespace['_rate_limit'] = None
-        namespace['_port'] = None
-        namespace['_default_headers'] = None
-        return super().__new__(cls, cls_name, bases, namespace)
+class BaseClient(ABC):
+    rate_limit = RateLimitAttr()
+    port = PortAttr()
 
-    @property
-    def rate_limit(cls) -> IRateLimit:
-        return cls._rate_limit
-
-    @rate_limit.setter
-    def rate_limit(cls, value: tuple[int, int] | IRateLimit) -> None:
-        if isinstance(value, IRateLimit):
-            cls._rate_limit = value
-        else:
-            raise TypeError('Value must implement IRateLimit interface')
-
-    @property
-    def port(cls) -> int:
-        return cls._port
-
-    @port.setter
-    def port(cls, value: int) -> None:
-        if isinstance(value, int) and 1 <= value <= 65535:
-            cls._port = value
-        else:
-            raise ValueError('Port must be between 1 and 65535')
-
-    @property
-    def default_headers(cls) -> Mapping[str, str]:
-        return cls._default_headers
-
-    @default_headers.setter
-    def default_headers(cls, value: Mapping[str, str]) -> None:
-        if isinstance(value, Mapping):
-            cls._default_headers = value
-        else:
-            raise TypeError('Value must be a mapping of headers to values')
-
-
-class BaseClient(ABC, metaclass=_ClientPropsMeta):
     def __init__(
             self,
             host: str,
             port: int | None = None,
-            context: IRateLimit | None = None,
-            headers: Mapping[str, str] | None = None
+            rate_limit: IRateLimit | None = None,
     ):
-        port = port or self.get_port()
-
-        self._context = context or self.get_rate_limit()
-
-        self._client_headers = headers or self.get_default_headers()
+        self.rate_limit = rate_limit
+        self.port = port
 
         if host.endswith('/'):
             host = host[:-1]
 
         self._host = host
-        self._api_url = f'{host}:{port}' if port is not None else host
+
+        if 'port' in get_path_params(host):
+            api_url = fill_path_params(host, {'port': port})
+        elif port is not None:
+            api_url = f'{host}:{port}'
+        else:
+            api_url = host
+
+        self._api_url = api_url
 
     @property
     def host(self) -> str:
         return self._host
-
-    @property
-    def context(self) -> IRateLimit:
-        return self._context
-
-    @classmethod
-    def get_rate_limit(cls) -> IRateLimit | None:
-        return cls._rate_limit
-
-    @classmethod
-    def set_rate_limit(cls, calls: int, period: int) -> None:
-        cls.rate_limit = calls, period
-
-    @classmethod
-    def get_port(cls) -> int | None:
-        return cls._port
-
-    @classmethod
-    def set_port(cls, port: int) -> None:
-        cls.port = port
-
-    @classmethod
-    def get_default_headers(cls) -> Mapping[str, str] | None:
-        return cls._default_headers
-
-    @classmethod
-    def set_default_headers(cls, headers: Mapping[str, str]) -> None:
-        cls.default_headers = headers
 
     @abstractmethod
     def request(self, method: str, *args, **kwargs) -> IResponse:

--- a/sensei/_descriptors.py
+++ b/sensei/_descriptors.py
@@ -1,0 +1,29 @@
+from sensei.types import IRateLimit
+
+
+class RateLimitAttr:
+    def __set_name__(self, owner: type, name: str) -> None:
+        self.name = name
+
+    def __get__(self, obj: object, owner: type) -> IRateLimit:
+        return obj.__dict__[self.name]
+
+    def __set__(self, obj: object, value: IRateLimit) -> None:
+        if value is None or isinstance(value, IRateLimit):
+            obj.__dict__[self.name] = value
+        else:
+            raise TypeError(f'Value must implement {IRateLimit} interface')
+
+
+class PortAttr:
+    def __set_name__(self, owner: type, name: str) -> None:
+        self.name = name
+
+    def __get__(self, obj: object, owner: type) -> IRateLimit:
+        return obj.__dict__[self.name]
+
+    def __set__(self, obj: object, value: IRateLimit) -> None:
+        if value is None or isinstance(value, int) and 1 <= value <= 65535:
+            obj.__dict__[self.name] = value
+        else:
+            raise ValueError('Port must be between 1 and 65535')

--- a/sensei/_internal/__init__.py
+++ b/sensei/_internal/__init__.py
@@ -1,2 +1,2 @@
 from ._core.router import Router
-from ._core import Args
+from ._core import Args, IRouter, RoutedMethod

--- a/sensei/_internal/__init__.py
+++ b/sensei/_internal/__init__.py
@@ -1,2 +1,2 @@
 from ._core.router import Router
-from ._core import Args, IRouter, RoutedMethod
+from ._core import Args, IRouter, RoutedMethod, Hook

--- a/sensei/_internal/__init__.py
+++ b/sensei/_internal/__init__.py
@@ -1,1 +1,2 @@
 from ._core.router import Router
+from ._core import Args

--- a/sensei/_internal/_core/__init__.py
+++ b/sensei/_internal/_core/__init__.py
@@ -1,0 +1,1 @@
+from ._endpoint import Args

--- a/sensei/_internal/_core/__init__.py
+++ b/sensei/_internal/_core/__init__.py
@@ -1,1 +1,2 @@
 from ._endpoint import Args
+from ._types import IRouter, RoutedMethod

--- a/sensei/_internal/_core/__init__.py
+++ b/sensei/_internal/_core/__init__.py
@@ -1,2 +1,3 @@
 from ._endpoint import Args
 from ._types import IRouter, RoutedMethod
+from ._hook import Hook

--- a/sensei/_internal/_core/_endpoint.py
+++ b/sensei/_internal/_core/_endpoint.py
@@ -23,6 +23,15 @@ def _identical(s: str) -> str: return s
 
 
 class Endpoint(Generic[ResponseModel]):
+    __slots__ = (
+        "_path",
+        "_method",
+        "_error_msg",
+        "_case_converters",
+        "_params_model",
+        "_response_model"
+    )
+
     def __init__(
             self,
             path: str,

--- a/sensei/_internal/_core/_endpoint.py
+++ b/sensei/_internal/_core/_endpoint.py
@@ -4,7 +4,8 @@ from pydantic.fields import FieldInfo
 from sensei.types import IResponse
 from sensei.params import Body, Query, Header, Cookie
 from sensei.cases import header_case as to_header_case
-from sensei._internal.tools import ChainedMap, fill_path_params, split_params, make_model, is_safe_method, HTTPMethod, validate_method
+from ..tools import (ChainedMap, fill_path_params, split_params, make_model, is_safe_method, HTTPMethod,
+                     validate_method, identical)
 
 CaseConverter = Callable[[str], str]
 ResponseTypes = type(BaseModel), str, dict, bytes
@@ -13,13 +14,10 @@ ResponseModel = TypeVar('ResponseModel', type[BaseModel], str, dict[str, Any], b
 
 class Args(BaseModel):
     url: str
-    params: dict[str, Any] | None = None
-    json_: dict[str, Any] | None = Field(None, alias="json")
-    headers: dict[str, Any] | None = None
-    cookies: dict[str, Any] | None = None
-
-
-def _identical(s: str) -> str: return s
+    params: dict[str, Any] = {}
+    json_: dict[str, Any] = Field({}, alias="json")
+    headers: dict[str, Any] = {}
+    cookies: dict[str, Any] = {}
 
 
 class Endpoint(Generic[ResponseModel]):
@@ -62,7 +60,7 @@ class Endpoint(Generic[ResponseModel]):
 
         for k in converters.keys():
             if converters[k] is None:
-                converters[k] = _identical
+                converters[k] = identical
 
         self._case_converters = converters
 

--- a/sensei/_internal/_core/_hook.py
+++ b/sensei/_internal/_core/_hook.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class Hook(Enum):
+    JSON_FINALIZER = "__finalize_json__"
+    ARGS_PREPARER = "__prepare_args__"
+
+    QUERY_CASE = "__query_case__"
+    BODY_CASE = "__body_case__"
+    COOKIE_CASE = "__cookie_case__"
+    HEADER_CASE = "__header_case__"
+
+    @classmethod
+    def values(cls) -> list[str]:
+        return [member.value for member in cls]

--- a/sensei/_internal/_core/_requester.py
+++ b/sensei/_internal/_core/_requester.py
@@ -1,22 +1,64 @@
 from abc import ABC, abstractmethod
 from functools import wraps
-from typing import Callable, Any, Generic
+from typing import Callable, Generic, TypeVar, Any
 from ._endpoint import Endpoint, Args, ResponseModel
 from sensei._base_client import BaseClient
 from sensei.client import Client, AsyncClient
-from sensei.types import IResponse
+from sensei.types import IResponse, IRequest
 
-Initializer = Callable[..., Args]
+_Any = TypeVar("_Any")
+
+Initializer = Callable[[Args], Args]
 Finalizer = Callable[[IResponse], ResponseModel]
+JsonDecorator = Callable[[dict[str, _Any]], dict[str, _Any]]
+
+
+class _DecoratedResponse(IResponse):
+    def __init__(
+            self,
+            response: IResponse,
+            json_decorator: JsonDecorator | None = None
+    ):
+        self._response = response
+        self._json_decorator = json_decorator if json_decorator is not None else lambda x: x
+
+    def json(self) -> dict[str, Any]:
+        return self._json_decorator(self._response.json())
+
+    def raise_for_status(self) -> IResponse:
+        return self._response.raise_for_status()
+
+    def request(self) -> IRequest:
+        return self._response.request
+
+    @property
+    def text(self) -> str:
+        return self._response.text
+
+    @property
+    def status_code(self) -> int:
+        return self._response.status_code
+
+    @property
+    def content(self) -> bytes:
+        return self._response.content
 
 
 class Requester(ABC, Generic[ResponseModel]):
+    __slots__ = (
+        "_client",
+        "_initializer",
+        "_finalizer",
+        "_endpoint"
+    )
+
     def __new__(
             cls,
             client: BaseClient,
             endpoint: Endpoint,
             initializer: Initializer | None = None,
-            finalizer: Finalizer | None = None
+            finalizer: Finalizer | None = None,
+            json_decorator: JsonDecorator | None = None
     ):
         if isinstance(client, AsyncClient):
             return super().__new__(_AsyncRequester)
@@ -30,12 +72,14 @@ class Requester(ABC, Generic[ResponseModel]):
             client: BaseClient,
             endpoint: Endpoint,
             initializer: Initializer | None = None,
-            finalizer: Finalizer | None = None
+            finalizer: Finalizer | None = None,
+            json_decorator: JsonDecorator | None = None
     ):
         self._client = client
         self._initializer = initializer or self._initialize
         self._finalizer = finalizer or self._finalize
         self._endpoint = endpoint
+        self._json_decorator = json_decorator
 
     @property
     def client(self) -> BaseClient:
@@ -45,9 +89,16 @@ class Requester(ABC, Generic[ResponseModel]):
     def endpoint(self) -> Endpoint:
         return self._endpoint
 
-    def _initialize(self, **kwargs) -> dict[str, Any]:
+    @staticmethod
+    def _initialize(args: Args) -> Args:
+        return args
+
+    def _get_args(self, **kwargs) -> dict[str, Any]:
         endpoint = self._endpoint
-        return endpoint.get_args(**kwargs).model_dump(mode="json", exclude_none=True, by_alias=True)
+        args = endpoint.get_args(**kwargs)
+        args = self._initializer(args).model_dump(mode="json", exclude_none=True, by_alias=True)
+
+        return {'method': endpoint.method, **args}
 
     def _finalize(self, response: IResponse) -> ResponseModel:
         endpoint = self._endpoint
@@ -64,16 +115,17 @@ class _AsyncRequester(Requester):
             client: BaseClient,
             endpoint: Endpoint,
             initializer: Initializer | None = None,
-            finalizer: Finalizer | None = None
+            finalizer: Finalizer | None = None,
+            json_decorator: JsonDecorator | None = None
     ):
-        super().__init__(client, endpoint, initializer, finalizer)
+        super().__init__(client, endpoint, initializer, finalizer, json_decorator)
 
     async def request(self, **kwargs) -> ResponseModel:
         client = self._client
-        endpoint = self._endpoint
+        args = self._get_args(**kwargs)
 
-        args = self._initializer(**kwargs)
-        response = await client.request(endpoint.method, **args)
+        response = await client.request(**args)
+        response = _DecoratedResponse(response, json_decorator=self._json_decorator)
         return self._finalizer(response)
 
     async def decorate(self, func: Callable):
@@ -90,14 +142,15 @@ class _Requester(Requester):
             client: BaseClient,
             endpoint: Endpoint,
             initializer: Initializer | None = None,
-            finalizer: Finalizer | None = None
+            finalizer: Finalizer | None = None,
+            json_decorator: JsonDecorator | None = None
     ):
-        super().__init__(client, endpoint, initializer, finalizer)
+        super().__init__(client, endpoint, initializer, finalizer, json_decorator)
 
     def request(self, **kwargs) -> ResponseModel:
         client = self._client
-        endpoint = self._endpoint
+        args = self._get_args(**kwargs)
 
-        args = self._initializer(**kwargs)
-        response = client.request(endpoint.method, **args)
+        response = client.request(**args)
+        response = _DecoratedResponse(response, json_decorator=self._json_decorator)
         return self._finalizer(response)

--- a/sensei/_internal/_core/_requester.py
+++ b/sensei/_internal/_core/_requester.py
@@ -1,16 +1,15 @@
 from abc import ABC, abstractmethod
 from functools import wraps
-from typing import Callable, Generic, TypeVar, Any
+from typing import Callable, Generic, Any
 from ._endpoint import Endpoint, Args, ResponseModel
 from sensei._base_client import BaseClient
 from sensei.client import Client, AsyncClient
 from sensei.types import IResponse, IRequest
 
-_Any = TypeVar("_Any")
 
 Initializer = Callable[[Args], Args]
 Finalizer = Callable[[IResponse], ResponseModel]
-JsonDecorator = Callable[[dict[str, _Any]], dict[str, _Any]]
+JsonDecorator = Callable[[dict[str, Any]], dict[str, Any]]
 
 
 class _DecoratedResponse(IResponse):

--- a/sensei/_internal/_core/_requester.py
+++ b/sensei/_internal/_core/_requester.py
@@ -7,22 +7,22 @@ from sensei.client import Client, AsyncClient
 from sensei.types import IResponse, IRequest
 
 
-Initializer = Callable[[Args], Args]
+Preparer = Callable[[Args], Args]
 Finalizer = Callable[[IResponse], ResponseModel]
-JsonDecorator = Callable[[dict[str, Any]], dict[str, Any]]
+JsonFinalizer = Callable[[dict[str, Any]], dict[str, Any]]
 
 
 class _DecoratedResponse(IResponse):
     def __init__(
             self,
             response: IResponse,
-            json_decorator: JsonDecorator | None = None
+            json_finalizer: JsonFinalizer | None = None
     ):
         self._response = response
-        self._json_decorator = json_decorator if json_decorator is not None else lambda x: x
+        self._json_finalizer = json_finalizer if json_finalizer is not None else lambda x: x
 
     def json(self) -> dict[str, Any]:
-        return self._json_decorator(self._response.json())
+        return self._json_finalizer(self._response.json())
 
     def raise_for_status(self) -> IResponse:
         return self._response.raise_for_status()
@@ -46,7 +46,7 @@ class _DecoratedResponse(IResponse):
 class Requester(ABC, Generic[ResponseModel]):
     __slots__ = (
         "_client",
-        "_initializer",
+        "_preparer",
         "_finalizer",
         "_endpoint"
     )
@@ -55,9 +55,9 @@ class Requester(ABC, Generic[ResponseModel]):
             cls,
             client: BaseClient,
             endpoint: Endpoint,
-            initializer: Initializer | None = None,
+            preparer: Preparer | None = None,
             finalizer: Finalizer | None = None,
-            json_decorator: JsonDecorator | None = None
+            json_finalizer: JsonFinalizer | None = None
     ):
         if isinstance(client, AsyncClient):
             return super().__new__(_AsyncRequester)
@@ -70,15 +70,15 @@ class Requester(ABC, Generic[ResponseModel]):
             self,
             client: BaseClient,
             endpoint: Endpoint,
-            initializer: Initializer | None = None,
+            preparer: Preparer | None = None,
             finalizer: Finalizer | None = None,
-            json_decorator: JsonDecorator | None = None
+            json_finalizer: JsonFinalizer | None = None
     ):
         self._client = client
-        self._initializer = initializer or self._initialize
+        self._preparer = preparer or self._prepare
         self._finalizer = finalizer or self._finalize
         self._endpoint = endpoint
-        self._json_decorator = json_decorator
+        self._json_finalizer = json_finalizer
 
     @property
     def client(self) -> BaseClient:
@@ -89,13 +89,13 @@ class Requester(ABC, Generic[ResponseModel]):
         return self._endpoint
 
     @staticmethod
-    def _initialize(args: Args) -> Args:
+    def _prepare(args: Args) -> Args:
         return args
 
     def _get_args(self, **kwargs) -> dict[str, Any]:
         endpoint = self._endpoint
         args = endpoint.get_args(**kwargs)
-        args = self._initializer(args).model_dump(mode="json", exclude_none=True, by_alias=True)
+        args = self._preparer(args).model_dump(mode="json", exclude_none=True, by_alias=True)
 
         return {'method': endpoint.method, **args}
 
@@ -113,18 +113,18 @@ class _AsyncRequester(Requester):
             self,
             client: BaseClient,
             endpoint: Endpoint,
-            initializer: Initializer | None = None,
+            preparer: Preparer | None = None,
             finalizer: Finalizer | None = None,
-            json_decorator: JsonDecorator | None = None
+            json_finalizer: JsonFinalizer | None = None
     ):
-        super().__init__(client, endpoint, initializer, finalizer, json_decorator)
+        super().__init__(client, endpoint, preparer, finalizer, json_finalizer)
 
     async def request(self, **kwargs) -> ResponseModel:
         client = self._client
         args = self._get_args(**kwargs)
 
         response = await client.request(**args)
-        response = _DecoratedResponse(response, json_decorator=self._json_decorator)
+        response = _DecoratedResponse(response, json_finalizer=self._json_finalizer)
         return self._finalizer(response)
 
     async def decorate(self, func: Callable):
@@ -140,16 +140,16 @@ class _Requester(Requester):
             self,
             client: BaseClient,
             endpoint: Endpoint,
-            initializer: Initializer | None = None,
+            preparer: Preparer | None = None,
             finalizer: Finalizer | None = None,
-            json_decorator: JsonDecorator | None = None
+            json_finalizer: JsonFinalizer | None = None
     ):
-        super().__init__(client, endpoint, initializer, finalizer, json_decorator)
+        super().__init__(client, endpoint, preparer, finalizer, json_finalizer)
 
     def request(self, **kwargs) -> ResponseModel:
         client = self._client
         args = self._get_args(**kwargs)
 
         response = client.request(**args)
-        response = _DecoratedResponse(response, json_decorator=self._json_decorator)
+        response = _DecoratedResponse(response, json_finalizer=self._json_finalizer)
         return self._finalizer(response)

--- a/sensei/_internal/_core/_route.py
+++ b/sensei/_internal/_core/_route.py
@@ -1,5 +1,6 @@
 import inspect
 from abc import ABC, abstractmethod
+from functools import wraps, partial
 from typing import Callable, TypeVar
 from sensei.client import Manager
 from ._endpoint import CaseConverter
@@ -7,6 +8,7 @@ from ..tools import HTTPMethod, MethodType, identical
 from sensei._base_client import BaseClient
 from ._callable_handler import CallableHandler
 from ._requester import ResponseFinalizer, Preparer, JsonFinalizer
+from sensei.types import IRateLimit
 
 _Client = TypeVar('_Client', bound=BaseClient)
 
@@ -17,24 +19,29 @@ class Route(ABC):
         '_method',
         '_func',
         '_manager',
-        '_default_host',
+        '_host',
+        '_port',
+        '_rate_limit',
         '_response_finalizer',
         '_method_type',
         '_is_async',
         '_case_converters',
         '_preparer',
         '_json_finalizer',
-        '_pre_preparer'
+        '_pre_preparer',
+        '__self__'
     )
 
     def __new__(
             cls,
             path: str,
             method: HTTPMethod,
-            /, *,
+            *,
             func: Callable,
             manager: Manager[_Client],
-            default_host: str,
+            host: str,
+            port: int | None = None,
+            rate_limit: IRateLimit | None = None,
             case_converters: dict[str, CaseConverter],
             json_finalizer: JsonFinalizer = identical,
             pre_preparer: Preparer = identical,
@@ -46,16 +53,6 @@ class Route(ABC):
             instance = super().__new__(_SyncRoute)
             is_async = False
 
-        instance.__init__(
-            path,
-            method,
-            func=func,
-            manager=manager,
-            default_host=default_host,
-            case_converters=case_converters,
-            json_finalizer=json_finalizer,
-            pre_preparer=pre_preparer
-        )
         instance._is_async = is_async
 
         return instance
@@ -64,10 +61,12 @@ class Route(ABC):
             self,
             path: str,
             method: HTTPMethod,
-            /, *,
+            *,
             func: Callable,
             manager: Manager[_Client],
-            default_host: str,
+            host: str,
+            port: int | None = None,
+            rate_limit: IRateLimit | None = None,
             case_converters: dict[str, CaseConverter],
             json_finalizer: JsonFinalizer | None = None,
             pre_preparer: Preparer = identical,
@@ -76,7 +75,10 @@ class Route(ABC):
         self._method = method
         self._func = func
         self._manager = manager
-        self._default_host = default_host
+        self._rate_limit = rate_limit
+
+        self._host = host
+        self._port = port
 
         self._response_finalizer: ResponseFinalizer | None = None
         self._preparer: Preparer = identical
@@ -86,6 +88,7 @@ class Route(ABC):
         self._case_converters = case_converters
         self._json_finalizer = json_finalizer
         self._pre_preparer = pre_preparer
+        self.__self__: object | None = None
 
     @property
     def path(self) -> str:
@@ -112,11 +115,23 @@ class Route(ABC):
         if isinstance(value, MethodType):
             self._method_type = value
         else:
-            raise TypeError(f'Method type must be an instance of {MethodType.__class__}')
+            raise TypeError(f'Method type must be an instance of {MethodType}')
+
+    def _get_wrapper(self, func: Callable[..., ...]):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            new_func = func
+
+            if self.__self__ is not None:
+                new_func = partial(func, self.__self__)
+
+            return new_func(*args, **kwargs)
+
+        return wrapper
 
     def finalize(self, func: ResponseFinalizer | None = None) -> Callable:
         def decorator(func: ResponseFinalizer) -> ResponseFinalizer:
-            self._response_finalizer = func
+            self._response_finalizer = self._get_wrapper(func)
             return func
 
         if func is None:
@@ -126,7 +141,7 @@ class Route(ABC):
 
     def prepare(self, func: Preparer | None = None) -> Callable:
         def decorator(func: Preparer) -> Preparer:
-            self._preparer = func
+            self._preparer = self._get_wrapper(func)
             return func
 
         if func is None:
@@ -139,7 +154,9 @@ class _SyncRoute(Route):
     def __call__(self, *args, **kwargs):
         with CallableHandler(
             func=self._func,
-            default_host=self._default_host,
+            host=self._host,
+            port=self._port,
+            rate_limit=self._rate_limit,
             request_args=(args, kwargs),
             manager=self._manager,
             method_type=self._method_type,
@@ -158,7 +175,9 @@ class _AsyncRoute(Route):
     async def __call__(self, *args, **kwargs):
         async with CallableHandler(
             func=self._func,
-            default_host=self._default_host,
+            host=self._host,
+            port=self._port,
+            rate_limit=self._rate_limit,
             request_args=(args, kwargs),
             manager=self._manager,
             method_type=self._method_type,

--- a/sensei/_internal/_core/_route.py
+++ b/sensei/_internal/_core/_route.py
@@ -6,7 +6,7 @@ from ._endpoint import CaseConverter
 from ..tools import HTTPMethod, MethodType
 from sensei._base_client import BaseClient
 from ._callable_handler import CallableHandler
-from ._requester import Finalizer, Initializer
+from ._requester import Finalizer, Initializer, JsonDecorator
 
 _Client = TypeVar('_Client', bound=BaseClient)
 
@@ -22,7 +22,8 @@ class Route(ABC):
         '_method_type',
         '_is_async',
         '_case_converters',
-        '_initializer'
+        '_initializer',
+        '_json_decorator'
     )
 
     def __new__(
@@ -33,7 +34,8 @@ class Route(ABC):
             func: Callable,
             manager: Manager[_Client],
             default_host: str,
-            case_converters: dict[str, CaseConverter]
+            case_converters: dict[str, CaseConverter],
+            json_decorator: JsonDecorator | None = None
     ):
         if inspect.iscoroutinefunction(func):
             instance = super().__new__(_AsyncRoute)
@@ -62,7 +64,8 @@ class Route(ABC):
             func: Callable,
             manager: Manager[_Client],
             default_host: str,
-            case_converters: dict[str, CaseConverter]
+            case_converters: dict[str, CaseConverter],
+            json_decorator: JsonDecorator | None = None
     ):
         self._path = path
         self._method = method
@@ -76,6 +79,7 @@ class Route(ABC):
         self._is_async = None
 
         self._case_converters = case_converters
+        self._json_decorator = json_decorator
 
     @property
     def path(self) -> str:
@@ -137,7 +141,8 @@ class _SyncRoute(Route):
             method=self._method,
             initializer=self._initializer,
             finalizer=self._finalizer,
-            case_converters=self._case_converters
+            case_converters=self._case_converters,
+            json_decorator=self._json_decorator
         ) as response:
             return response
 
@@ -154,6 +159,7 @@ class _AsyncRoute(Route):
             method=self._method,
             initializer=self._initializer,
             finalizer=self._finalizer,
-            case_converters=self._case_converters
+            case_converters=self._case_converters,
+            json_decorator=self._json_decorator
         ) as response:
             return response

--- a/sensei/_internal/_core/_types.py
+++ b/sensei/_internal/_core/_types.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Protocol, TypeVar, Any
 from ._endpoint import CaseConverter
-from ._requester import Finalizer, Initializer
+from ._requester import Finalizer, Preparer
 from ..tools import MethodType
 
 
@@ -9,10 +9,10 @@ class RoutedFunction(Protocol):
     def __call__(self, *args, **kwargs):
         ...
 
-    def initializer(self, initializer: Initializer) -> Initializer:
+    def prepare(self, preparer: Preparer) -> Preparer:
         ...
 
-    def finalizer(self, finalizer: Finalizer) -> Finalizer:
+    def finalize(self, finalizer: Finalizer) -> Finalizer:
         ...
 
     __method_type__: MethodType
@@ -29,7 +29,7 @@ class RoutedMethod(Protocol):
 class RoutedModel(Protocol):
     __router__ = ...
 
-    def __process_json__(self, value: dict[str, Any]) -> dict[str, Any]:
+    def __finalize_json__(self, value: dict[str, Any]) -> dict[str, Any]:
         pass
 
 

--- a/sensei/_internal/_core/_types.py
+++ b/sensei/_internal/_core/_types.py
@@ -1,0 +1,102 @@
+from abc import ABC, abstractmethod
+from typing import Protocol, TypeVar, Any
+from ._endpoint import CaseConverter
+from ._requester import Finalizer, Initializer
+from ..tools import MethodType
+
+
+class RoutedFunction(Protocol):
+    def __call__(self, *args, **kwargs):
+        ...
+
+    def initializer(self, initializer: Initializer) -> Initializer:
+        ...
+
+    def finalizer(self, finalizer: Finalizer) -> Finalizer:
+        ...
+
+    __method_type__: MethodType
+    __name__: str
+    __doc__: str
+
+
+class RoutedMethod(Protocol):
+    __func__: RoutedFunction
+    __name__: str
+    __doc__: str
+
+
+class RoutedModel(Protocol):
+    __router__ = ...
+
+    def __process_json__(self, value: dict[str, Any]) -> dict[str, Any]:
+        pass
+
+
+SameModel = TypeVar("SameModel", bound=RoutedModel)
+
+
+class IRouter(ABC):
+    @abstractmethod
+    def model(self, model_obj: SameModel) -> SameModel:
+        pass
+
+    @abstractmethod
+    def get(
+            self,
+            path: str,
+            /, *,
+            query_case: CaseConverter | None = None,
+            body_case: CaseConverter | None = None,
+            cookie_case: CaseConverter | None = None,
+            header_case: CaseConverter | None = None
+    ) -> RoutedFunction:
+        pass
+
+    @abstractmethod
+    def post(
+            self,
+            path: str,
+            /, *,
+            query_case: CaseConverter | None = None,
+            body_case: CaseConverter | None = None,
+            cookie_case: CaseConverter | None = None,
+            header_case: CaseConverter | None = None
+    ) -> RoutedFunction:
+        pass
+
+    @abstractmethod
+    def patch(
+            self,
+            path: str,
+            /, *,
+            query_case: CaseConverter | None = None,
+            body_case: CaseConverter | None = None,
+            cookie_case: CaseConverter | None = None,
+            header_case: CaseConverter | None = None,
+    ) -> RoutedFunction:
+        pass
+
+    @abstractmethod
+    def put(
+            self,
+            path: str,
+            /, *,
+            query_case: CaseConverter | None = None,
+            body_case: CaseConverter | None = None,
+            cookie_case: CaseConverter | None = None,
+            header_case: CaseConverter | None = None
+    ) -> RoutedFunction:
+        pass
+
+    @abstractmethod
+    def delete(
+            self,
+            path: str,
+            /, *,
+            query_case: CaseConverter | None = None,
+            body_case: CaseConverter | None = None,
+            cookie_case: CaseConverter | None = None,
+            header_case: CaseConverter | None = None
+    ) -> RoutedFunction:
+        pass

--- a/sensei/_internal/_core/_types.py
+++ b/sensei/_internal/_core/_types.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Protocol, TypeVar, Any
+from typing import Protocol, TypeVar
 from ._endpoint import CaseConverter
-from ._requester import Finalizer, Preparer
+from ._requester import ResponseFinalizer, Preparer, JsonFinalizer
 from ..tools import MethodType
 
 
@@ -12,7 +12,7 @@ class RoutedFunction(Protocol):
     def prepare(self, preparer: Preparer) -> Preparer:
         ...
 
-    def finalize(self, finalizer: Finalizer) -> Finalizer:
+    def finalize(self, finalizer: ResponseFinalizer) -> ResponseFinalizer:
         ...
 
     __method_type__: MethodType
@@ -28,15 +28,20 @@ class RoutedMethod(Protocol):
 
 class RoutedModel(Protocol):
     __router__ = ...
-
-    def __finalize_json__(self, value: dict[str, Any]) -> dict[str, Any]:
-        pass
+    __finalize_json__: JsonFinalizer
+    __prepare_args__: Preparer
+    __query_case__: CaseConverter
+    __body_case__: CaseConverter
+    __cookie_case__: CaseConverter
+    __header_case__: CaseConverter
 
 
 SameModel = TypeVar("SameModel", bound=RoutedModel)
 
 
 class IRouter(ABC):
+    __slots__ = ()
+
     @abstractmethod
     def model(self, model_obj: SameModel) -> SameModel:
         pass

--- a/sensei/_internal/_core/router.py
+++ b/sensei/_internal/_core/router.py
@@ -5,6 +5,7 @@ from ._endpoint import CaseConverter
 from ._requester import Finalizer
 from ._route import Route
 from ..tools import HTTPMethod, set_method_type, MethodType
+from ..tools.utils import bind_attributes
 
 
 class RoutedFunction(Protocol):
@@ -15,10 +16,11 @@ class RoutedFunction(Protocol):
         ...
 
     __method_type__: MethodType
-    __route__: Route
 
 
 class Router:
+    __slots__ = "_manager", "_default_host", "_converters"
+
     def __init__(
             self,
             default_host: str,
@@ -93,8 +95,7 @@ class Router:
                     route.method_type = wrapper.__method_type__
                     return await route(*args, **kwargs)
 
-            setattr(wrapper, 'finalizer', route.finalizer)
-            setattr(wrapper, '__route__', route)
+            bind_attributes(wrapper, route.finalizer, route.initializer)  # type: ignore
             return wrapper
 
         return decorator

--- a/sensei/_internal/tools/__init__.py
+++ b/sensei/_internal/tools/__init__.py
@@ -1,4 +1,3 @@
 from .chained_map import ChainedMap
-from .utils import (fill_path_params, make_model, split_params, is_safe_method, validate_method, args_to_kwargs,
-                    set_method_type, identical)
+from .utils import make_model, split_params, is_safe_method, validate_method, args_to_kwargs, set_method_type, identical
 from .types import HTTPMethod, MethodType

--- a/sensei/_internal/tools/__init__.py
+++ b/sensei/_internal/tools/__init__.py
@@ -1,4 +1,4 @@
 from .chained_map import ChainedMap
 from .utils import (fill_path_params, make_model, split_params, is_safe_method, validate_method, args_to_kwargs,
-                    set_method_type)
+                    set_method_type, identical)
 from .types import HTTPMethod, MethodType

--- a/sensei/_internal/tools/utils.py
+++ b/sensei/_internal/tools/utils.py
@@ -1,9 +1,9 @@
-import re
 import sys
 import inspect
 from functools import wraps
 from pydantic import BaseModel
 from collections import OrderedDict
+from sensei._utils import get_path_params
 from typing import Any, get_args, Callable, TypeVar
 from .types import HTTPMethod, MethodType
 from pydantic._internal._model_construction import ModelMetaclass
@@ -36,16 +36,8 @@ def make_model(model_name: str, model_args: dict[str, Any]) -> type[BaseModel]:
         return model
 
 
-def _path_params(url: str) -> list[str]:
-    pattern = r'\{(\w+)\}'
-
-    parameters = re.findall(pattern, url)
-
-    return parameters
-
-
 def split_params(url: str, params: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
-    path_params_names = _path_params(url)
+    path_params_names = get_path_params(url)
 
     path_params = {}
     for path_param_name in path_params_names:
@@ -53,18 +45,6 @@ def split_params(url: str, params: dict[str, Any]) -> tuple[dict[str, Any], dict
         del params[path_param_name]
 
     return params, path_params
-
-
-def fill_path_params(url: str, values: dict[str, Any]) -> str:
-    pattern = r'\{(\w+)\}'
-
-    def replace_match(match: re.Match) -> str:
-        param_name = match.group(1)
-        return str(values.get(param_name, match.group(0)))
-
-    new_url = re.sub(pattern, replace_match, url)
-
-    return new_url
 
 
 def is_safe_method(method: HTTPMethod) -> bool:

--- a/sensei/_internal/tools/utils.py
+++ b/sensei/_internal/tools/utils.py
@@ -4,9 +4,15 @@ import inspect
 from functools import wraps
 from pydantic import BaseModel
 from collections import OrderedDict
-from typing import Any, get_args, Callable
+from typing import Any, get_args, Callable, TypeVar, Protocol, Iterable
 from .types import HTTPMethod, MethodType
 from pydantic._internal._model_construction import ModelMetaclass
+
+_Object = TypeVar("_Object")
+
+
+class _NamedObj(Protocol):
+    __name__ = ...
 
 
 def make_model(model_name: str, model_args: dict[str, Any]) -> type[BaseModel]:
@@ -114,3 +120,10 @@ def set_method_type(func: Callable):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+def bind_attributes(obj: _Object, *named_objects: tuple[_NamedObj]) -> _Object:
+    for named_obj in named_objects:
+        setattr(obj, named_obj.__name__, named_obj)
+
+    return obj

--- a/sensei/_internal/tools/utils.py
+++ b/sensei/_internal/tools/utils.py
@@ -4,15 +4,11 @@ import inspect
 from functools import wraps
 from pydantic import BaseModel
 from collections import OrderedDict
-from typing import Any, get_args, Callable, TypeVar, Protocol
+from typing import Any, get_args, Callable, TypeVar
 from .types import HTTPMethod, MethodType
 from pydantic._internal._model_construction import ModelMetaclass
 
-_Object = TypeVar("_Object")
-
-
-class _NamedObj(Protocol):
-    __name__ = ...
+_T = TypeVar("_T")
 
 
 def make_model(model_name: str, model_args: dict[str, Any]) -> type[BaseModel]:
@@ -122,8 +118,5 @@ def set_method_type(func: Callable):
     return wrapper
 
 
-def bind_attributes(obj: _Object, *named_objects: tuple[_NamedObj]) -> _Object:
-    for named_obj in named_objects:
-        setattr(obj, named_obj.__name__, named_obj)
-
-    return obj
+def identical(value: _T) -> _T:
+    return value

--- a/sensei/_internal/tools/utils.py
+++ b/sensei/_internal/tools/utils.py
@@ -4,7 +4,7 @@ import inspect
 from functools import wraps
 from pydantic import BaseModel
 from collections import OrderedDict
-from typing import Any, get_args, Callable, TypeVar, Protocol, Iterable
+from typing import Any, get_args, Callable, TypeVar, Protocol
 from .types import HTTPMethod, MethodType
 from pydantic._internal._model_construction import ModelMetaclass
 

--- a/sensei/_utils.py
+++ b/sensei/_utils.py
@@ -15,7 +15,8 @@ def is_classmethod(obj: Any) -> bool:
     if inspect.ismethod(obj):
         cond2 = isinstance(obj.__self__, type)
     else:
-        cond3 = hasattr(obj, '__func__') and hasattr(obj, '__doc__') and hasattr(obj, '__name__')
+        cond3 = (hasattr(obj, '__func__') and hasattr(obj, '__doc__') and hasattr(obj, '__name__')
+                 and hasattr(obj, '__isabstractmethod__') and not hasattr(obj, '__call__'))
 
     return cond1 or cond2 or cond3
 

--- a/sensei/_utils.py
+++ b/sensei/_utils.py
@@ -3,23 +3,20 @@ from typing import Any
 
 
 def is_classmethod(obj: Any) -> bool:
-    class _Temp:
-        @classmethod
-        def class_method(cls):
-            pass
-
-    type_ = type(_Temp.class_method)
-    cond1 = isinstance(obj, type_)
-
-    cond2 = cond3 = False
-    if inspect.ismethod(obj):
-        cond2 = isinstance(obj.__self__, type)
-    else:
-        cond3 = (hasattr(obj, '__func__') and hasattr(obj, '__doc__') and hasattr(obj, '__name__')
-                 and hasattr(obj, '__isabstractmethod__') and not hasattr(obj, '__call__'))
-
-    return cond1 or cond2 or cond3
+    return isinstance(obj, classmethod)
 
 
-def is_self_method(obj: Any) -> bool:
-    return inspect.ismethod(obj) or is_classmethod(obj)
+def is_staticmethod(obj: Any) -> bool:
+    return isinstance(obj, staticmethod)
+
+
+def is_instancemethod(obj: Any) -> bool:
+    return inspect.isfunction(obj)
+
+
+def is_selfmethod(obj: Any) -> bool:
+    return is_classmethod(obj) or is_instancemethod(obj)
+
+
+def is_method(obj: Any) -> bool:
+    return is_selfmethod(obj) or is_staticmethod(obj)

--- a/sensei/_utils.py
+++ b/sensei/_utils.py
@@ -1,5 +1,11 @@
 import inspect
-from typing import Any
+from typing import Any, TypeVar, Protocol
+
+_T = TypeVar("_T")
+
+
+class _NamedObj(Protocol):
+    __name__ = ...
 
 
 def is_classmethod(obj: Any) -> bool:
@@ -20,3 +26,10 @@ def is_selfmethod(obj: Any) -> bool:
 
 def is_method(obj: Any) -> bool:
     return is_selfmethod(obj) or is_staticmethod(obj)
+
+
+def bind_attributes(obj: _T, *named_objects: tuple[_NamedObj]) -> _T:
+    for named_obj in named_objects:
+        setattr(obj, named_obj.__name__, named_obj)
+
+    return obj

--- a/sensei/_utils.py
+++ b/sensei/_utils.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 from typing import Any, TypeVar, Protocol
 
 _T = TypeVar("_T")
@@ -33,3 +34,23 @@ def bind_attributes(obj: _T, *named_objects: tuple[_NamedObj]) -> _T:
         setattr(obj, named_obj.__name__, named_obj)
 
     return obj
+
+
+def get_path_params(url: str) -> list[str]:
+    pattern = r'\{(\w+)\}'
+
+    parameters = re.findall(pattern, url)
+
+    return parameters
+
+
+def fill_path_params(url: str, values: dict[str, Any]) -> str:
+    pattern = r'\{(\w+)\}'
+
+    def replace_match(match: re.Match) -> str:
+        param_name = match.group(1)
+        return str(values.get(param_name, match.group(0)))
+
+    new_url = re.sub(pattern, replace_match, url)
+
+    return new_url

--- a/sensei/api_model.py
+++ b/sensei/api_model.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from pydantic._internal._model_construction import ModelMetaclass
+from ._internal.tools.utils import bind_attributes
 from ._utils import is_self_method
 
 
@@ -8,7 +9,9 @@ class _Namespace(dict):
         if is_self_method(value):
             try:
                 finalizer = value.__func__.finalizer
-                setattr(value, 'finalizer', finalizer)
+                initializer = value.__func__.initializer
+
+                bind_attributes(value, finalizer, initializer)
             except AttributeError:
                 pass
         super().__setitem__(key, value)

--- a/sensei/api_model.py
+++ b/sensei/api_model.py
@@ -1,19 +1,26 @@
+from typing import Any
 from pydantic import BaseModel
 from pydantic._internal._model_construction import ModelMetaclass
+from ._internal import IRouter, RoutedMethod
 from ._internal.tools.utils import bind_attributes
 from ._utils import is_self_method
 
 
 class _Namespace(dict):
+    @staticmethod
+    def _decorate_self_method(method: RoutedMethod) -> None:
+        try:
+            finalizer = method.__func__.finalizer
+            initializer = method.__func__.initializer
+
+            bind_attributes(method, finalizer, initializer)  # type: ignore
+            method.__func__.__self__ = 'Hello'
+        except AttributeError:
+            pass
+
     def __setitem__(self, key, value):
         if is_self_method(value):
-            try:
-                finalizer = value.__func__.finalizer
-                initializer = value.__func__.initializer
-
-                bind_attributes(value, finalizer, initializer)
-            except AttributeError:
-                pass
+            self._decorate_self_method(value)
         super().__setitem__(key, value)
 
 
@@ -22,7 +29,17 @@ class _ModelMeta(ModelMetaclass):
     def __prepare__(metacls, name, bases):
         return _Namespace()
 
+    def __new__(cls, name, bases, dct):
+        obj = super().__new__(cls, name, bases, dct)
+        obj.__router__ = None
+
+        return obj
+
 
 class APIModel(BaseModel, metaclass=_ModelMeta):
+    @staticmethod
+    def __process_json__(json: dict[str, Any]) -> dict[str, Any]:
+        return json
+
     def __str__(self):
         return f'{self.__class__.__name__}({super().__str__()})'

--- a/sensei/api_model.py
+++ b/sensei/api_model.py
@@ -2,8 +2,8 @@ import functools
 from typing import Any
 from pydantic import BaseModel
 from pydantic._internal._model_construction import ModelMetaclass
-from ._internal import RoutedMethod
-from ._internal.tools.utils import bind_attributes
+from ._internal import RoutedMethod, Hook, Args
+from ._utils import bind_attributes
 from ._utils import is_staticmethod, is_classmethod, is_selfmethod
 
 
@@ -21,7 +21,7 @@ class _Namespace(dict):
     def __setitem__(self, key: Any, value: Any):
         if is_staticmethod(value) or is_classmethod(value):
             self._decorate_method(value)
-        elif key == '__finalize_json__' and is_selfmethod(value):
+        elif key in Hook.values() and is_selfmethod(value):
             value = functools.partial(value, None)
 
         super().__setitem__(key, value)
@@ -48,6 +48,26 @@ class APIModel(BaseModel, metaclass=_ModelMeta):
     @staticmethod
     def __finalize_json__(json: dict[str, Any]) -> dict[str, Any]:
         return json
+
+    @staticmethod
+    def __prepare_args__(args: Args) -> Args:
+        return args
+
+    @staticmethod
+    def __query_case__(s: str) -> str:
+        return s
+
+    @staticmethod
+    def __body_case__(s: str) -> str:
+        return s
+
+    @staticmethod
+    def __cookie_case__(s: str) -> str:
+        return s
+
+    @staticmethod
+    def __header_case__(s: str) -> str:
+        return s
 
     def __str__(self):
         return f'{self.__class__.__name__}({super().__str__()})'

--- a/sensei/client/client.py
+++ b/sensei/client/client.py
@@ -14,7 +14,7 @@ class Client(_Client, BaseClient):
             *,
             host: str,
             port: int | None = None,
-            context: IRateLimit | None = None,
+            rate_limit: IRateLimit | None = None,
             auth: AuthTypes | None = None,
             params: QueryParamTypes | None = None,
             headers: HeaderTypes | None = None,
@@ -36,7 +36,7 @@ class Client(_Client, BaseClient):
             trust_env: bool = True,
             default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
     ) -> None:
-        BaseClient.__init__(self, host=host, port=port, context=context, headers=headers)
+        BaseClient.__init__(self, host=host, port=port, rate_limit=rate_limit)
         _Client.__init__(
             self,
             auth=auth,
@@ -79,10 +79,8 @@ class Client(_Client, BaseClient):
             timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
             extensions: RequestExtensions | None = None,
     ) -> Response:
-        headers = headers or self._client_headers
-
-        if self.context:
-            RateLimiter(self.context).wait_for_slot()
+        if self.rate_limit:
+            RateLimiter(self.rate_limit).wait_for_slot()
 
         return super().request(
             method,
@@ -107,7 +105,7 @@ class AsyncClient(_AsyncClient, BaseClient):
             *,
             host: str,
             port: int | None = None,
-            context: IRateLimit | None = None,
+            rate_limit: IRateLimit | None = None,
             auth: AuthTypes | None = None,
             params: QueryParamTypes | None = None,
             headers: HeaderTypes | None = None,
@@ -129,7 +127,7 @@ class AsyncClient(_AsyncClient, BaseClient):
             trust_env: bool = True,
             default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
     ) -> None:
-        BaseClient.__init__(self, host=host, port=port, context=context, headers=headers)
+        BaseClient.__init__(self, host=host, port=port, rate_limit=rate_limit)
         _AsyncClient.__init__(
             self,
             auth=auth,
@@ -172,10 +170,8 @@ class AsyncClient(_AsyncClient, BaseClient):
             timeout: TimeoutTypes | UseClientDefault = USE_CLIENT_DEFAULT,
             extensions: RequestExtensions | None = None,
     ) -> Response:
-        headers = headers or self._client_headers
-
-        if self.context:
-            await AsyncRateLimiter(self.context).wait_for_slot()
+        if self.rate_limit:
+            await AsyncRateLimiter(self.rate_limit).wait_for_slot()
 
         return await super().request(
             method,

--- a/sensei/client/manager.py
+++ b/sensei/client/manager.py
@@ -7,6 +7,8 @@ _ClientToInstantiate = type[_Client] | _Client
 
 
 class Manager(Generic[_Client]):
+    __slots__ = ('_client', '_client_type')
+
     def __init__(self, client: _Client):
         if isinstance(client, BaseClient):
             self._client = client

--- a/sensei/client/manager.py
+++ b/sensei/client/manager.py
@@ -22,7 +22,7 @@ class Manager(Generic[_Client]):
             if self._client is None:
                 self._client = client
             else:
-                raise CollectionLimitError(self.__class__.__name__, 1, "Client")
+                raise CollectionLimitError(self.__class__, 1, "Client")
         else:
             raise TypeError(f"Client must be an instance of {self._client_type.__name__}")
 

--- a/sensei/client/rate_limiter.py
+++ b/sensei/client/rate_limiter.py
@@ -6,6 +6,8 @@ from sensei.types import IRateLimit
 
 
 class RateLimit(IRateLimit):
+    __slots__ = "_tokens", "_last_checked", "_async_lock", "_thread_lock"
+
     def __init__(self, calls: int, period: int) -> None:
         """
         Initialize the shared state for rate limiting.

--- a/sensei/types.py
+++ b/sensei/types.py
@@ -79,6 +79,8 @@ class IRequest(Protocol):
 
 
 class IResponse(Protocol):
+    __slots__ = ()
+
     def __await__(self):
         pass
 

--- a/sensei/types.py
+++ b/sensei/types.py
@@ -16,7 +16,7 @@ class IRateLimit(ABC):
         self._period: int = period
 
     @property
-    def period(self):
+    def period(self) -> int:
         return self._period
 
     @period.setter
@@ -85,7 +85,7 @@ class IResponse(Protocol):
         pass
 
     @abstractmethod
-    def json(self) -> dict[str, Any]:
+    def json(self) -> dict[str, Any] | list:
         pass
 
     @abstractmethod

--- a/sensei/types.py
+++ b/sensei/types.py
@@ -3,6 +3,8 @@ from typing import Protocol, Mapping, Self, Any
 
 
 class IRateLimit(ABC):
+    __slots__ = "_calls", "_period"
+
     def __init__(self, calls: int, period: int) -> None:
         """
         Initialize the shared state for rate limiting.
@@ -80,24 +82,30 @@ class IResponse(Protocol):
     def __await__(self):
         pass
 
+    @abstractmethod
     def json(self) -> dict[str, Any]:
         pass
 
+    @abstractmethod
     def raise_for_status(self) -> Self:
         pass
 
     @property
+    @abstractmethod
     def request(self) -> IRequest:
         pass
 
     @property
+    @abstractmethod
     def text(self) -> str:
         pass
 
     @property
+    @abstractmethod
     def status_code(self) -> int:
         pass
 
     @property
+    @abstractmethod
     def content(self) -> bytes:
         pass


### PR DESCRIPTION
**Added:**
- Finalizers and preparers as class or instance methods.
- Request rate limit and port through `Router` instance.
- Setting Self, list[Self] and list[<API_MODEL>] as response types
- Adding hooks `__finalize_json__`, `__prepare_args__`, `__query_case__`,  `__body_case__`, `__cookie_case__`, `__header_case__` for `APIModel` class.

